### PR TITLE
bug: JWT 자격 증명 실패, 비밀번호 불일치 오류 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+	implementation("javax.xml.bind:jaxb-api:2.3.1")
+	implementation("org.glassfish.jaxb:jaxb-runtime:2.3.1")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("org.postgresql:postgresql")
 	annotationProcessor("org.projectlombok:lombok")

--- a/src/main/kotlin/com/yugyeong/iamstar/config/WebConfig.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/config/WebConfig.kt
@@ -1,0 +1,16 @@
+package com.yugyeong.iamstar.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173") // 프론트엔드 주소
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
@@ -5,13 +5,15 @@ import com.yugyeong.iamstar.dto.SignUpRequest
 import com.yugyeong.iamstar.model.User
 import com.yugyeong.iamstar.service.UserService
 import com.yugyeong.iamstar.util.JwtUtil
+import com.yugyeong.iamstar.service.UserDetailsService
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetails
-import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.bind.annotation.*
+import org.slf4j.LoggerFactory
 
 @RestController
 class UserController(
@@ -20,33 +22,57 @@ class UserController(
     private val jwtUtil: JwtUtil,
     private val userDetailsService: UserDetailsService,
     private val passwordEncoder: PasswordEncoder
-
 ) {
+    private val logger = LoggerFactory.getLogger(UserController::class.java)
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
-    fun signup(@RequestBody signupRequest: SignUpRequest) {
+    fun signup(@RequestBody signupRequest: SignUpRequest): Map<String, String> {
+        val encodedPassword = passwordEncoder.encode(signupRequest.password)
         val user = User(
             email = signupRequest.email,
-            password = passwordEncoder.encode(signupRequest.password),
+            password = encodedPassword,
             username = signupRequest.username,
             fullName = signupRequest.fullName
         )
         userService.save(user)
+        logger.info("사용자 가입 성공: ${signupRequest.email}")
+        logger.info("사용자가 회원가입한 비밀번호: ${signupRequest.password}")
+        logger.info("저장된 해시된 비밀번호: $encodedPassword")
+
     }
 
     @PostMapping("/signin")
     fun signin(@RequestBody signInRequest: SignInRequest): String {
-        val authenticationToken = UsernamePasswordAuthenticationToken(signInRequest.email, signInRequest.password)
-        authenticationManager.authenticate(authenticationToken)
+        try {
+            val userDetails: UserDetails = userDetailsService.loadUserByUsername(signInRequest.email)
+            logger.info("로그인 시 입력한 이메일: ${signInRequest.email}")
 
-        val userDetails: UserDetails = userDetailsService.loadUserByUsername(signInRequest.email)
+            // 비밀번호 비교
+            val matches = passwordEncoder.matches(signInRequest.password, userDetails.password)
+            logger.info("로그인 시 입력한 비밀번호: ${signInRequest.password}")
+            logger.info("데이터베이스에 저장된 해시된 비밀번호: ${userDetails.password}")
+            logger.info("비밀번호 일치 여부: $matches")
 
-        // 비밀번호 비교
-        if (passwordEncoder.matches(signInRequest.password, userDetails.password)) {
-            return jwtUtil.generateToken(userDetails.username)
-        } else {
-            throw RuntimeException("Invalid credentials")
+            if (matches) {
+                logger.info("비밀번호 매칭 성공")
+                val authenticationToken = UsernamePasswordAuthenticationToken(signInRequest.email, signInRequest.password)
+                authenticationManager.authenticate(authenticationToken)
+                logger.info("사용자 인증 성공: ${signInRequest.email}")
+
+                val token = jwtUtil.generateToken(userDetails.username)
+                logger.info("JWT 토큰 생성 성공: ${signInRequest.email}")
+                return token
+            } else {
+                logger.error("비밀번호 불일치: ${signInRequest.email}")
+                throw RuntimeException("비밀번호가 일치하지 않습니다.")
+            }
+        } catch (e: BadCredentialsException) {
+            logger.error("로그인 실패: 자격 증명에 실패하였습니다.")
+            throw RuntimeException("자격 증명에 실패하였습니다. 이메일과 비밀번호를 확인해주세요.")
+        } catch (e: Exception) {
+            logger.error("로그인 중 예기치 않은 오류 발생: ${e.message}")
+            throw RuntimeException("로그인 중 오류가 발생했습니다. 다시 시도해주세요.")
         }
     }
 }

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
@@ -40,6 +40,7 @@ class UserController(
         logger.info("사용자가 회원가입한 비밀번호: ${signupRequest.password}")
         logger.info("저장된 해시된 비밀번호: $encodedPassword")
 
+        return mapOf("username" to user.username) // username 리턴
     }
 
     @PostMapping("/signin")

--- a/src/main/kotlin/com/yugyeong/iamstar/filter/JwtRequestFilter.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/filter/JwtRequestFilter.kt
@@ -30,6 +30,7 @@ class JwtRequestFilter(
 
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             jwt = authorizationHeader.substring(7)
+            println("Extracted JWT: $jwt")
             username = jwtUtil.extractAllClaims(jwt).subject
         }
 

--- a/src/main/kotlin/com/yugyeong/iamstar/service/UserDetailsService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/UserDetailsService.kt
@@ -7,7 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 
 @Service
-class UserDetailService(
+class UserDetailsService(
     private val userRepository: UserRepository
 ) : UserDetailsService {
 

--- a/src/main/kotlin/com/yugyeong/iamstar/service/UserService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/UserService.kt
@@ -12,8 +12,7 @@ class UserService(
 ) {
 
     fun save(user: User): User {
-        val hashedPassword = passwordEncoder.encode(user.password)
-        val userWithHashedPassword = user.copy(password = hashedPassword)
-        return userRepository.save(userWithHashedPassword)
-    }
+        // 여기서 다시 비밀번호를 해싱하지 않습니다.
+        return userRepository.save(user)
+   }
 }

--- a/src/main/kotlin/com/yugyeong/iamstar/util/JwtUtil.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/util/JwtUtil.kt
@@ -13,18 +13,22 @@ class JwtUtil {
     private lateinit var secretKey: String
 
     fun generateToken(username: String): String {
-        return Jwts.builder()
+        val token = Jwts.builder()
             .setSubject(username)
             .setIssuedAt(Date())
             .setExpiration(Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10시간 유효
             .signWith(SignatureAlgorithm.HS256, secretKey)
             .compact()
+        println("Generated Token: $token") // 토큰 생성 로깅
+        return token
     }
 
     fun validateToken(token: String, username: String): Boolean {
         val claims = extractAllClaims(token)
         val tokenUsername = claims.subject
-        return (username == tokenUsername && !isTokenExpired(token))
+        val isValid = (username == tokenUsername && !isTokenExpired(token))
+        println("Token Validation: $isValid") // 토큰 유효성 검사 로깅
+        return isValid
     }
 
     internal fun extractAllClaims(token: String): Claims {


### PR DESCRIPTION
## 회원가입/로그인 로직

- 회원가입 요청
- `BCryptPasswordEncoder`를 통해 회원가입 시 입력된 password를 해싱
- 해시된 password를 데이터베이스에 저장한다.
- 로그인 요청
- 데이터베이스에서 해당 email을 가진 사용자를 찾는다.
- 사용자가 로그인 시 입력된 password와 데이터베이스에 저장된 해시된 password가 일치하는지 확인한다.
    
    `PasswordEncoder`의 `matches`를 통해 rawPassword와 encodedPassword를 비교한다.
    
    BCrypt와 같은 해시 알고리즘을 사용하면 같은 매번 다른 해시값이 생성되지만, 해시값(encodedPassword)에 포함된 솔트(salt) 정보를 통해 rawPassword를 같은 방식으로 해싱하여 비교한다.
    
- 일치하면 `true`를 반환하고, 그렇지 않으면 `false`를 반환한다.

<aside>
🤖 로그인 시 입력한 비밀번호의 해시 값과 데이터베이스에 저장된 해시된 비밀번호가 다른 이유는 `BCryptPasswordEncoder`의 `encode` 메서드가 항상 다른 해시 값을 생성하기 때문입니다.

`BCrypt`는 각 해시를 만들 때마다 무작위 솔트(salt)를 생성하고, 이 솔트와 함께 비밀번호를 해시합니다. 따라서 같은 비밀번호도 매번 다른 해시 값을 가지게 됩니다.

비밀번호 비교는 해시된 비밀번호 자체를 비교하는 것이 아니라, 입력된 비밀번호를 데이터베이스에 저장된 해시된 비밀번호와 매칭시키는 것입니다.

 이는 `BCryptPasswordEncoder`의 `matches` 메서드를 사용하여 수행됩니다.

 `matches` 메서드는 입력된 비밀번호를 동일한 솔트로 해시하고, 이 결과를 데이터베이스에 저장된 해시와 비교합니다.

따라서 다음과 같이 `matches` 메서드를 사용하면 문제가 해결됩니다

</aside>

---

## Error 원인

- **이중 해싱**

`UserController`의 `matches`에서 rawPassword를 자동으로 해싱을 하는데, 그걸 모르고 `UserService`에서 password를 이중으로 해싱하여, 데이터베이스의 password와 로그인 시 입력받은 password가 다른 문제 발생.

- **의존성 누락**

`javax.xml.bind.DatatypeConverter`의 `jjwt`의 메서드를 사용하여 Base64 인코딩과 디코딩을 수행하는데, 이에 대한 의존성이 누락되었다.

- **시크릿 키**

PowerShell 명령을 사용한 시크릿 키 생성
$secret = [System.Guid]::NewGuid().ToString("N") + [System.Guid]::NewGuid().ToString("N")
$secret