### PR TITLE
bug: User not found로 게시물이 보이지 않는 버그 해결 & feature: 게시물 like 구현

### DIFF
--- a/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
@@ -29,6 +29,13 @@ class PostController @Autowired constructor(
         return postService.getAllPosts()
     }
 
+    @PostMapping("/{postId}/like")
+    fun likePost(@PathVariable postId: String) {
+        val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
+        val userId = userDetails.id
+        postService.likePost(postId, userId)
+    }
+
     @PostMapping("/{postId}/comment")
     fun addComment(@PathVariable postId: String, @RequestBody comment: Comment): ResponseEntity<Post> {
         val savedPost = postService.addComment(postId, comment)

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
@@ -36,6 +36,13 @@ class PostController @Autowired constructor(
         postService.likePost(postId, userId)
     }
 
+    @PostMapping("/{postId}/unlike")
+    fun unlikePost(@PathVariable postId: String) {
+        val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
+        val userId = userDetails.id
+        postService.unlikePost(postId, userId)
+    }
+
     @PostMapping("/{postId}/comment")
     fun addComment(@PathVariable postId: String, @RequestBody comment: Comment): ResponseEntity<Post> {
         val savedPost = postService.addComment(postId, comment)

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
@@ -5,10 +5,10 @@ import com.yugyeong.iamstar.dto.PostResponse
 import com.yugyeong.iamstar.model.Comment
 import com.yugyeong.iamstar.model.Post
 import com.yugyeong.iamstar.service.PostService
+import com.yugyeong.iamstar.service.UserDetails
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -18,11 +18,10 @@ class PostController @Autowired constructor(
 ) {
 
     @PostMapping
-    fun createPost(@RequestBody postRequest: PostRequest): ResponseEntity<Post> {
+    fun createPost(@RequestBody postRequest: PostRequest) {
         val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
-        val email = userDetails.username
-        val savedPost = postService.createPost(email, postRequest)
-        return ResponseEntity.ok(savedPost)
+        val userId = userDetails.id
+        postService.createPost(userId, postRequest)
     }
 
     @GetMapping

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
@@ -20,8 +20,8 @@ class PostController @Autowired constructor(
     @PostMapping
     fun createPost(@RequestBody postRequest: PostRequest): ResponseEntity<Post> {
         val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
-        val userId = userDetails.username
-        val savedPost = postService.createPost(userId, postRequest)
+        val email = userDetails.username
+        val savedPost = postService.createPost(email, postRequest)
         return ResponseEntity.ok(savedPost)
     }
 

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/PostController.kt
@@ -43,6 +43,14 @@ class PostController @Autowired constructor(
         postService.unlikePost(postId, userId)
     }
 
+    @GetMapping("/{postId}/isLiked")
+    fun isLiked(@PathVariable postId: String): Map<String, Boolean> {
+        val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
+        val userId = userDetails.id
+        val isLiked = postService.isLiked(postId, userId)
+        return mapOf("isLiked" to isLiked)
+    }
+
     @PostMapping("/{postId}/comment")
     fun addComment(@PathVariable postId: String, @RequestBody comment: Comment): ResponseEntity<Post> {
         val savedPost = postService.addComment(postId, comment)

--- a/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/controller/UserController.kt
@@ -33,7 +33,7 @@ class UserController(
             email = signupRequest.email,
             password = encodedPassword,
             username = signupRequest.username,
-            fullName = signupRequest.fullName,
+            fullName = signupRequest.fullName
         )
         userService.save(user)
         logger.info("사용자 가입 성공: ${signupRequest.email}")

--- a/src/main/kotlin/com/yugyeong/iamstar/model/Post.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/model/Post.kt
@@ -10,7 +10,7 @@ data class Post(
     val userId: String,
     val content: String,
     val postUrl: String,
-    val likes: Int = 0,
+    var likes: MutableList<String> = mutableListOf(),
     val comments: List<Comment> = listOf(),
     var timestamp: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/com/yugyeong/iamstar/model/User.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/model/User.kt
@@ -3,7 +3,7 @@ package com.yugyeong.iamstar.model
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
-const val DEFAULT_PROFILE_IMAGE_URL = "https://iamstar.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png\n"
+const val DEFAULT_PROFILE_IMAGE_URL = "https://iamstar.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png"
 
 @Document(collection = "user")
 data class User(

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -52,6 +52,14 @@ class PostService @Autowired constructor(
         }
     }
 
+    fun unlikePost(postId: String, userId: String) {
+        val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
+        if (post.likes.contains(userId)) {
+            post.likes.remove(userId)
+            postRepository.save(post)
+        }
+    }
+
     fun addComment(postId: String, comment: Comment): Post {
         val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
         val user = userRepository.findById(comment.userId).orElseThrow { RuntimeException("User not found") }

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -60,6 +60,11 @@ class PostService @Autowired constructor(
         }
     }
 
+    fun isLiked(postId: String, userId: String): Boolean {
+        val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
+        return post.likes.contains(userId)
+    }
+
     fun addComment(postId: String, comment: Comment): Post {
         val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
         val user = userRepository.findById(comment.userId).orElseThrow { RuntimeException("User not found") }

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -44,6 +44,14 @@ class PostService @Autowired constructor(
         }
     }
 
+    fun likePost(postId: String, userId: String) {
+        val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
+        if (!post.likes.contains(userId)) {
+            post.likes.add(userId)
+            postRepository.save(post)
+        }
+    }
+
     fun addComment(postId: String, comment: Comment): Post {
         val post = postRepository.findById(postId).orElseThrow { RuntimeException("Post not found") }
         val user = userRepository.findById(comment.userId).orElseThrow { RuntimeException("User not found") }

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -31,13 +31,13 @@ class PostService @Autowired constructor(
         return postRepository.findAllByOrderByTimestampDesc().map { post ->
             val user = userRepository.findById(post.userId).orElseThrow { RuntimeException("User with ID ${post.userId} not found") }
             PostResponse(
-                id = post.id!!,
+                id = post.id!!,  // null이 아님을 보장
                 username = user.username,
                 fullName = user.fullName,
                 profileUrl = user.profileUrl,
                 content = post.content,
                 postUrl = post.postUrl,
-                likes = post.likes,
+                likes = post.likes.size, // 게시글을 좋아요한 사용자 수를 반환
                 comments = post.comments,
                 timestamp = post.timestamp
             )

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -15,9 +15,12 @@ class PostService @Autowired constructor(
     private val postRepository: PostRepository,
     private val userRepository: UserRepository
 ) {
-    fun createPost(userId: String, postRequest: PostRequest): Post {
+    fun createPost(email: String, postRequest: PostRequest): Post {
+        val user = userRepository.findByEmail(email)
+            ?: throw RuntimeException("User not found with email: $email")
+
         val post = Post(
-            userId = userId,
+            userId = user.id!!,
             content = postRequest.content,
             postUrl = postRequest.postUrl,
             timestamp = LocalDateTime.now()
@@ -28,7 +31,7 @@ class PostService @Autowired constructor(
 
     fun getAllPosts(): List<PostResponse> {
         return postRepository.findAllByOrderByTimestampDesc().map { post ->
-            val user = userRepository.findById(post.userId).orElseThrow { RuntimeException("User not found") }
+            val user = userRepository.findById(post.userId).orElseThrow { RuntimeException("User with ID ${post.userId} not found") }
             PostResponse(
                 id = post.id!!,
                 username = user.username,

--- a/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/PostService.kt
@@ -15,12 +15,10 @@ class PostService @Autowired constructor(
     private val postRepository: PostRepository,
     private val userRepository: UserRepository
 ) {
-    fun createPost(email: String, postRequest: PostRequest): Post {
-        val user = userRepository.findByEmail(email)
-            ?: throw RuntimeException("User not found with email: $email")
 
+    fun createPost(userId: String, postRequest: PostRequest): Post {
         val post = Post(
-            userId = user.id!!,
+            userId = userId,
             content = postRequest.content,
             postUrl = postRequest.postUrl,
             timestamp = LocalDateTime.now()

--- a/src/main/kotlin/com/yugyeong/iamstar/service/UserDetails.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/UserDetails.kt
@@ -1,0 +1,26 @@
+package com.yugyeong.iamstar.service
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class UserDetails(
+    val id: String,
+    private val email: String,
+    private val password: String,
+    private val authorities: Collection<GrantedAuthority>
+) : UserDetails {
+
+    override fun getAuthorities(): Collection<GrantedAuthority> = authorities
+
+    override fun getPassword(): String = password
+
+    override fun getUsername(): String = email
+
+    override fun isAccountNonExpired(): Boolean = true
+
+    override fun isAccountNonLocked(): Boolean = true
+
+    override fun isCredentialsNonExpired(): Boolean = true
+
+    override fun isEnabled(): Boolean = true
+}

--- a/src/main/kotlin/com/yugyeong/iamstar/service/UserDetailsService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/UserDetailsService.kt
@@ -15,9 +15,11 @@ class UserDetailsService(
         val user = userRepository.findByEmail(email)
             ?: throw UsernameNotFoundException("User not found with email: $email")
 
-        return org.springframework.security.core.userdetails.User.withUsername(user.email)
-            .password(user.password)
-            .authorities(emptyList())
-            .build()
+        return UserDetails(
+            id = user.id!!,
+            email = user.email,
+            password = user.password,
+            authorities = emptyList()
+        )
     }
 }

--- a/src/main/kotlin/com/yugyeong/iamstar/service/UserService.kt
+++ b/src/main/kotlin/com/yugyeong/iamstar/service/UserService.kt
@@ -2,17 +2,15 @@ package com.yugyeong.iamstar.service
 
 import com.yugyeong.iamstar.model.User
 import com.yugyeong.iamstar.repository.UserRepository
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class UserService(
-    private val userRepository: UserRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val userRepository: UserRepository
 ) {
 
     fun save(user: User): User {
-        // 여기서 다시 비밀번호를 해싱하지 않습니다.
+        // 여기서 다시 비밀번호를 해싱하지 않는다.
         return userRepository.save(user)
    }
 }


### PR DESCRIPTION
# bug: User not found로 게시물이 보이지 않는 버그 해결
## 문제

메인 화면에서 다른 사용자들이 업로드한 Post들을 조회할 때 User를 찾지 못하는 문제 발생

## 원인

1. 새로운 Post를 업로드할 때 사용자의 이메일 아이디를 통해 현재 로그인 중인 사용자를 조회한다.
    
    이때, `userDetails.username`은 email인데, userId로 착각하여 문제가 발생
    
    → userId를 모두 email로 변경
    

1. userId에 null이 들어갈 수 있는 구조이지만, nullable하지 않아 문제가 발생
    
    → nullable하도록 Exception 처리, 로그 추가

---
# feature: 게시물 좋아요 구현
## Like

`MutableList<String>` 타입의 `likes` 필드를 이용하여 사용자가 이미 좋아요를 눌렀는지 확인하는 과정을 거친다.

- `likePost`: 
특정 게시물에 대해 사용자가 아직 좋아요를 누르지 않은 경우, `post.likes` 리스트에 사용자 ID를 추가하여 사용자의 좋아요를 추가한다.
- `unlikePost`: 특정 게시글에 대해 사용자가 이미 좋아요를 누른 경우, `post.likes` 리스트에서 사용자 ID를 제거하여 특정 사용자의 좋아요를 제거한다.
- `isLiked`: 특정 사용자가 특정 게시글에 대해 좋아요를 눌렀는지 여부를 확인하여 반환한다.

## 추가 변경 사항

UserDetails에서 email을 받아와 email로 사용자를 검색하여 userId를 찾던 로직을, UserDetails에서 userId를 바로 받아오도록 변경하였다.

### UserDetails

Spring Security의 `UserDetails` 인터페이스를 구현하여 사용자 정보를 나타낸다.

- `id`: 사용자의 고유 식별자
- `email`: 사용자의 이메일 주소로, `username` 역할을 한다.
- `password`: 사용자 암호
- `authorities`: 사용자가 가지고 있는 권한 목록
- `getAuthorities()`: 사용자가 가진 권한을 반환한다.
- `getPassword()`: 사용자 암호를 반환한다.
- `getUsername()`: 사용자의 이메일(`username`)을 반환한다.
- `isAccountNonExpired()`, `isAccountNonLocked()`, `isCredentialsNonExpired()`, `isEnabled()`: 계정 상태를 나타내는 부울 값을 반환한다. 여기서는 모두 `true`로 설정되어 있어 계정이 만료되지 않고 잠기지 않았으며 자격 증명이 만료되지 않고 활성 상태임을 나타낸다.

### UserDetailsService

Spring Security에서 `UserDetailsService` 인터페이스를 구현하여 사용자 인증을 위한 사용자의 정보를 데이터베이스에서 로드한다.

Spring Security에서 사용자가 로그인할 때 호출되어, 사용자의 이메일로 `UserDetails` 객체를 생성하여 반환한다. 이를 통해 Spring Security는 사용자 인증 과정을 처리한다.

- `loadUserByUsername(email: String)`: 주어진 이메일로 사용자를 검색하여 `UserDetails` 객체를 반환한다.